### PR TITLE
Feature/hybrid and long read assemblies

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -483,7 +483,7 @@ define(['backbone', 'underscore', './util'], function (
         });
 
         /**
-         * 
+         * Assembly - Runs collection
          */
         const AssemblyRuns = Backbone.Collection.extend({
             model: Run,
@@ -772,10 +772,7 @@ define(['backbone', 'underscore', './util'], function (
                     return Analysis.prototype.parse(analysis);
                 });
                 analyses = _.filter(analyses, (analysis) => {
-                    return !_.contains(
-                        ['assembly','hybrid_assembly','long_reads_assembly'],
-                        analysis['experiment_type']
-                    );
+                    return !analysis.isAssembly();
                 });
                 return analyses;
             }
@@ -819,10 +816,7 @@ define(['backbone', 'underscore', './util'], function (
                 });
                 if (this.assemblies === 'exclude') {
                     analyses = _.filter(analyses, (analysis) => {
-                        return !_.contains(
-                            ['assembly','hybrid_assembly','long_reads_assembly'],
-                            analysis['experiment_type']
-                        );
+                        return !Analysis.prototype.isAssembly(analysis['experiment_type']);
                     });
                 }
                 return analyses;

--- a/src/api.js
+++ b/src/api.js
@@ -672,7 +672,7 @@ define(['backbone', 'underscore', './util'], function (
              * Returns true if analysis experiment type is either:
              * - assembly
              * - hybrid_assembly
-             * - long_read_assembly
+             * - long_reads_assembly
              * @param experimentType: if provided will return the value based on this value,
              * otherwise on the model's instance data
              * @returns boolean

--- a/src/api.js
+++ b/src/api.js
@@ -772,7 +772,7 @@ define(['backbone', 'underscore', './util'], function (
                     return Analysis.prototype.parse(analysis);
                 });
                 analyses = _.filter(analyses, (analysis) => {
-                    return !analysis.isAssembly();
+                    return !Analysis.prototype.isAssembly(analysis['experiment_type']);
                 });
                 return analyses;
             }

--- a/src/api.js
+++ b/src/api.js
@@ -478,7 +478,6 @@ define(['backbone', 'underscore', './util'], function (
                     }),
                     wgs_id: attr['wgs-accession'],
                     legacy_id: attr['legacy-accession'],
-                    hybrid: attr['hybrid'],
                 };
             }
         });

--- a/src/charts/qcChart.js
+++ b/src/charts/qcChart.js
@@ -1,6 +1,7 @@
 define([
-    './genericChart', 'highcharts', 'highcharts/modules/exporting', '../util'
-], function(GenericChart, Highcharts, exporting, util) {
+    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting', '../util'
+], function(underscore, GenericChart, Highcharts, exporting, util) {
+    const _ = underscore;
     exporting(Highcharts);
 
     /**
@@ -102,7 +103,11 @@ define([
             if (params.analysesModel) {
                 const analysis = params.analysesModel;
                 that.data = analysis.get('analysis_summary');
-                that.data.is_assembly = analysis.get('experiment_type') === 'assembly';
+                that.data.is_assembly = _.contains(
+                    ['assembly','hybrid_assembly','long_reads_assembly'],
+                    analysis.get('experiment_type')
+                );
+
                 if (parseFloat(analysis.get('pipeline_version')) > 3.0) {
                     return qcStats.fetch({dataType: 'text'}).then(() => {
                         that.data.sequence_count = qcStats.get('sequence_count');
@@ -114,7 +119,10 @@ define([
                 const analysis = new this.api.Analysis({id: params['accession']});
                 return analysis.fetch().then(() => {
                     that.data = analysis['attributes']['analysis_summary'];
-                    that.data['is_assembly'] = analysis['attributes']['experiment_type'] === 'assembly';
+                    that.data.is_assembly = _.contains(
+                        ['assembly','hybrid_assembly','long_reads_assembly'],
+                        analysis['attributes']['experiment_type']
+                    );
                     if (parseFloat(analysis['attributes']['pipeline_version']) > 3.0) {
                         return qcStats.fetch({dataType: 'text'});
                     } else {

--- a/src/charts/qcChart.js
+++ b/src/charts/qcChart.js
@@ -119,10 +119,7 @@ define([
                 const analysis = new this.api.Analysis({id: params['accession']});
                 return analysis.fetch().then(() => {
                     that.data = analysis['attributes']['analysis_summary'];
-                    that.data.is_assembly = _.contains(
-                        ['assembly','hybrid_assembly','long_reads_assembly'],
-                        analysis['attributes']['experiment_type']
-                    );
+                    that.data.is_assembly = analysis.isAssembly();
                     if (parseFloat(analysis['attributes']['pipeline_version']) > 3.0) {
                         return qcStats.fetch({dataType: 'text'});
                     } else {

--- a/src/charts/qcChart.js
+++ b/src/charts/qcChart.js
@@ -103,11 +103,7 @@ define([
             if (params.analysesModel) {
                 const analysis = params.analysesModel;
                 that.data = analysis.get('analysis_summary');
-                that.data.is_assembly = _.contains(
-                    ['assembly','hybrid_assembly','long_reads_assembly'],
-                    analysis.get('experiment_type')
-                );
-
+                that.data.is_assembly = analysis.isAssembly();
                 if (parseFloat(analysis.get('pipeline_version')) > 3.0) {
                     return qcStats.fetch({dataType: 'text'}).then(() => {
                         that.data.sequence_count = qcStats.get('sequence_count');

--- a/src/charts/seqFeatSumChart.js
+++ b/src/charts/seqFeatSumChart.js
@@ -25,11 +25,11 @@ define([
                     return;
                 }
 
-                // This is repeated with the model. I didn't merge the code
+                // This is repeated in the Analysis model. I didn't merge the code
                 // because the GenericChart method doesn't include the api if
-                // the data is passed as parameter. Changing that could cause
-                // other problems. Considering how close we are to migrate the whole app
-                // I would spend time re-factoring this.
+                // the data is passed as a parameter. Changing that could cause
+                // other problems. Considering how close we are to the migration
+                // of the whole app, I would not spend time re-factoring this.
                 const isAssembly = _.contains(
                     ['assembly','hybrid_assembly','long_reads_assembly'],
                     this.data['experiment_type']

--- a/src/charts/seqFeatSumChart.js
+++ b/src/charts/seqFeatSumChart.js
@@ -1,5 +1,5 @@
 define([
-    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting',
+    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting', '../api'
 ], function(underscore, GenericChart, Highcharts, exporting, api) {
     const _ = underscore;
     exporting(Highcharts);
@@ -25,7 +25,7 @@ define([
                     return;
                 }
 
-                const isAssembly = this.api.Analysis.prototype.isAssembly(this.data['experiment_type']);
+                const isAssembly = api.Analysis.prototype.isAssembly(this.data['experiment_type']);
 
                 // TODO: remove mapping when https://www.ebi.ac.uk/panda/jira/browse/EMG-1672
                 let categories = [

--- a/src/charts/seqFeatSumChart.js
+++ b/src/charts/seqFeatSumChart.js
@@ -1,6 +1,6 @@
 define([
-    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting', '../util'
-], function(underscore, GenericChart, Highcharts, exporting, util) {
+    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting',
+], function(underscore, GenericChart, Highcharts, exporting) {
     const _ = underscore;
     exporting(Highcharts);
 
@@ -24,7 +24,11 @@ define([
                     this.loaded.reject();
                     return;
                 }
-                const isAssembly = this.data['experiment_type'] === 'assembly'
+
+                const isAssembly = _.contains(
+                    ['assembly','hybrid_assembly','long_reads_assembly'],
+                    this.data['experiment_type']
+                );
 
                 // TODO: remove mapping when https://www.ebi.ac.uk/panda/jira/browse/EMG-1672
                 let categories = [

--- a/src/charts/seqFeatSumChart.js
+++ b/src/charts/seqFeatSumChart.js
@@ -1,6 +1,6 @@
 define([
     'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting',
-], function(underscore, GenericChart, Highcharts, exporting) {
+], function(underscore, GenericChart, Highcharts, exporting, api) {
     const _ = underscore;
     exporting(Highcharts);
 
@@ -25,10 +25,7 @@ define([
                     return;
                 }
 
-                const isAssembly = _.contains(
-                    ['assembly','hybrid_assembly','long_reads_assembly'],
-                    this.data['experiment_type']
-                );
+                const isAssembly = this.api.Analysis.prototype.isAssembly(this.data['experiment_type']);
 
                 // TODO: remove mapping when https://www.ebi.ac.uk/panda/jira/browse/EMG-1672
                 let categories = [

--- a/src/charts/seqFeatSumChart.js
+++ b/src/charts/seqFeatSumChart.js
@@ -1,6 +1,6 @@
 define([
-    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting', '../api'
-], function(underscore, GenericChart, Highcharts, exporting, api) {
+    'underscore', './genericChart', 'highcharts', 'highcharts/modules/exporting',
+], function(underscore, GenericChart, Highcharts, exporting) {
     const _ = underscore;
     exporting(Highcharts);
 
@@ -25,7 +25,15 @@ define([
                     return;
                 }
 
-                const isAssembly = api.Analysis.prototype.isAssembly(this.data['experiment_type']);
+                // This is repeated with the model. I didn't merge the code
+                // because the GenericChart method doesn't include the api if
+                // the data is passed as parameter. Changing that could cause
+                // other problems. Considering how close we are to migrate the whole app
+                // I would spend time re-factoring this.
+                const isAssembly = _.contains(
+                    ['assembly','hybrid_assembly','long_reads_assembly'],
+                    this.data['experiment_type']
+                );
 
                 // TODO: remove mapping when https://www.ebi.ac.uk/panda/jira/browse/EMG-1672
                 let categories = [

--- a/tests/assembly_test.js
+++ b/tests/assembly_test.js
@@ -55,7 +55,7 @@ define(['api'], function (api) {
             });
         });
         context('Assembly analyses', function () {
-            it('Should only retrieve analyses of experiment type  assembly', function (done) {
+            it('Should only retrieve analyses of experiment type assembly', function (done) {
                 const assemblyAccession = 'ERZ477708';
                 const collection = new api.AssemblyAnalyses({
                     id: assemblyAccession


### PR DESCRIPTION
Assembly analysis fall in 3 categories now:
- assembly (good'ol assemblies)
- long_reads
- hybrid
The only change users should note on the website is going to be on the Analysis landing page. The instruments used for sequencing will be inferred from the Reads not the analysis for hybrids.
