### PR TITLE
Europe PMC Publication annotations

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1025,17 +1025,29 @@ define(['backbone', 'underscore', './util'], function (
             parse(d) {
                 const data = d.data !== undefined ? d.data : d;
 
-                let annotations = data['annotation_types'];
+                let annotations = data;
 
-                _.mapObject(annotations, function (annotationIncidences) {
-                    return _.map(annotationIncidences, function(annotation) {
-                        annotation.sectionName = annotation.section.split(" (")[0];
-                        return annotation
+                _.mapObject(annotations, function(annotationTypeGroups) {
+                    return _.map(annotationTypeGroups, function (annotationTypeGroup) {
+                        annotationTypeGroup.annotations = _.map(annotationTypeGroup.annotations, function (annotation) {
+                            annotation.sectionName = annotation.section.split(" (")[0];
+                            return annotation
+                        });
+                        return annotationTypeGroup;
                     });
                 });
 
                 return {
-                    annotations: annotations,
+                    annotations: [
+                        {
+                            'sectionTitle': 'Sample processing',
+                            'groupedAnnotations': annotations.sample_processing
+                        },
+                        {
+                            'sectionTitle': 'Other annotations',
+                            'groupedAnnotations': annotations.other
+                        }
+                    ],
                 }
             }
         })

--- a/src/api.js
+++ b/src/api.js
@@ -1018,6 +1018,28 @@ define(['backbone', 'underscore', './util'], function (
             }
         });
 
+        const PublicationEuropePMCAnnotations = Backbone.Model.extend({
+            url() {
+                return API_URL + 'publications/' + this.id + '/europe_pmc_annotations';
+            },
+            parse(d) {
+                const data = d.data !== undefined ? d.data : d;
+
+                let annotations = data['annotation_types'];
+
+                _.mapObject(annotations, function (annotationIncidences) {
+                    return _.map(annotationIncidences, function(annotation) {
+                        annotation.sectionName = annotation.section.split(" (")[0];
+                        return annotation
+                    });
+                });
+
+                return {
+                    annotations: annotations,
+                }
+            }
+        })
+
         const Genome = Backbone.Model.extend({
             url() {
                 return API_URL + 'genomes/' + this.id;
@@ -1312,6 +1334,7 @@ define(['backbone', 'underscore', './util'], function (
             Publication,
             PublicationsCollection,
             PublicationStudies,
+            PublicationEuropePMCAnnotations,
             Genome,
             GenomesCollection,
             GenomeDownloads,


### PR DESCRIPTION
This PR:
- adds MGnify API consumer for getting the Europe PMC annotations on a Publication.